### PR TITLE
VCST-2198: Fix logout from Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ The list of other parameters can be found in the [OpenIdConnectOptions](https://
     "Authority": "https://accounts.google.com",
     "ClientId": "your-client-id",
     "ClientSecret": "your-client-secret",
-    "UserNameClaimType": "email"
-  }
+    "UserNameClaimType": "email",
+    "EndSessionEndpoint": "https://accounts.google.com/Logout"
+}
 ```
 
 ### Example settings for Microsoft
@@ -105,7 +106,8 @@ The list of other parameters can be found in the [OpenIdConnectOptions](https://
       "ClientSecret": "your-client-secret",
       "UserNameClaimType": "email",
       "CallbackPath": "/signin-google",
-      "SignedOutCallbackPath": "/signout-google"
+      "SignedOutCallbackPath": "/signout-google",
+      "EndSessionEndpoint": "https://accounts.google.com/Logout"
     },
     {
       "Enabled": true,

--- a/src/VirtoCommerce.OpenIdConnectModule.Core/Models/OidcOptions.cs
+++ b/src/VirtoCommerce.OpenIdConnectModule.Core/Models/OidcOptions.cs
@@ -56,4 +56,6 @@ public class OidcOptions
     /// URL of the logo for the OpenId Connect authentication provider.
     /// </summary>
     public string LogoUrl { get; set; } = "Modules/$(VirtoCommerce.OpenIdConnectModule)/Content/openid-icon.webp";
+
+    public string EndSessionEndpoint { get; set; }
 }

--- a/src/VirtoCommerce.OpenIdConnectModule.Web/Module.cs
+++ b/src/VirtoCommerce.OpenIdConnectModule.Web/Module.cs
@@ -78,6 +78,17 @@ public class Module : IModule, IHasConfiguration
                         return Task.CompletedTask;
                     };
 
+                    openIdConnectOptions.Events.OnRedirectToIdentityProviderForSignOut = context =>
+                    {
+                        if (string.IsNullOrEmpty(context.ProtocolMessage.IssuerAddress) &&
+                            !string.IsNullOrEmpty(options.EndSessionEndpoint))
+                        {
+                            context.ProtocolMessage.IssuerAddress = options.EndSessionEndpoint;
+                        }
+
+                        return Task.CompletedTask;
+                    };
+
                     openIdConnectOptions.Events.OnAccessDenied = context =>
                     {
                         // Need a base URI (any) to work with relative URLs


### PR DESCRIPTION
## Description
Added a new setting `EndSessionEndpoint` which should be set to `https://accounts.google.com/Logout` for the Google provider:
```json
{
  ...
  "EndSessionEndpoint": "https://accounts.google.com/Logout"
}
```
## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-2198
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.OpenIdConnectModule_3.801.0-pr-3-0f63.zip