### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.803.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.OpenIdConnectModule.Core/VirtoCommerce.OpenIdConnectModule.Core.csproj
+++ b/src/VirtoCommerce.OpenIdConnectModule.Core/VirtoCommerce.OpenIdConnectModule.Core.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.865.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.OpenIdConnectModule.Data/VirtoCommerce.OpenIdConnectModule.Data.csproj
+++ b/src/VirtoCommerce.OpenIdConnectModule.Data/VirtoCommerce.OpenIdConnectModule.Data.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.865.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OpenIdConnectModule.Core\VirtoCommerce.OpenIdConnectModule.Core.csproj" />

--- a/src/VirtoCommerce.OpenIdConnectModule.Web/VirtoCommerce.OpenIdConnectModule.Web.csproj
+++ b/src/VirtoCommerce.OpenIdConnectModule.Web/VirtoCommerce.OpenIdConnectModule.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
@@ -14,7 +14,7 @@
     <None Remove="Scripts\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.OpenIdConnectModule.Core\VirtoCommerce.OpenIdConnectModule.Core.csproj" />

--- a/src/VirtoCommerce.OpenIdConnectModule.Web/module.manifest
+++ b/src/VirtoCommerce.OpenIdConnectModule.Web/module.manifest
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.OpenIdConnectModule</id>
-  <version>3.803.0</version>
+  <version>3.1000.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.865.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies />
 
   <title>OpenID Connect</title>
@@ -26,7 +26,7 @@
   <moduleType>VirtoCommerce.OpenIdConnectModule.Web.Module, VirtoCommerce.OpenIdConnectModule.Web</moduleType>
 
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2024 VirtoCommerce. All rights reserved</copyright>
+  <copyright>Copyright © 2024-2026 VirtoCommerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
 </module>

--- a/tests/VirtoCommerce.OpenIdConnectModule.Tests/VirtoCommerce.OpenIdConnectModule.Tests.csproj
+++ b/tests/VirtoCommerce.OpenIdConnectModule.Tests/VirtoCommerce.OpenIdConnectModule.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -8,13 +8,13 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
feat: Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.OpenIdConnectModule_3.1000.0-pr-5-80bf.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Framework and dependency upgrades can introduce runtime/behavior changes in authentication and module integration despite minimal code edits. Risk is mainly compatibility/regression with the VirtoCommerce platform and updated OpenID Connect/auth packages.
> 
> **Overview**
> Updates the OpenID Connect module to target `net10.0` across Core, Data, Web, and Tests, and bumps the module version to `3.1000.0`.
> 
> Aligns dependencies with the newer VirtoCommerce platform by updating `VirtoCommerce.Platform.*` references to `3.1002.0`, upgrades `Microsoft.AspNetCore.Authentication.OpenIdConnect` to `10.0.1`, and refreshes test tooling (coverlet, `Microsoft.NET.Test.Sdk`, and migrates to `xunit.v3`). Also updates `module.manifest` `platformVersion` and copyright years.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80bfa4d3f7ce10f3e92f389bd61d4fc4b3644082. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->